### PR TITLE
Fix: Corrected include path for header component

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,7 +15,7 @@
     @endauth
 </head>
 <body id="top" class="dark-mode @if(auth()->check() && !auth()->user()->isAdmin() && !auth()->user()->isVendor()) user-theme @endif">
-    @include('components.header')
+    @include('components/header')
 
     
         @auth


### PR DESCRIPTION
Changed the include path for the header component in `resources/views/layouts/app.blade.php` from `components.header` to `components/header` to resolve the `View not found` error.