### PR TITLE
Fix(cart): Add getTotalItems method to Cart model

### DIFF
--- a/app/Models/Cart.php
+++ b/app/Models/Cart.php
@@ -226,4 +226,17 @@ class Cart extends Model
                 return $item->getTotalPrice();
             });
     }
+
+    /**
+     * Get the total number of items in the user's cart.
+     *
+     * @return int
+     */
+    public static function getTotalItems()
+    {
+        if (auth()->check()) {
+            return self::where('user_id', auth()->id())->sum('quantity');
+        }
+        return 0;
+    }
 }


### PR DESCRIPTION
Implements the `getTotalItems` static method in the `Cart` model to calculate the total number of items in your cart. This resolves the `BadMethodCallException` that occurred when calling this method from the header view to display the cart item count.